### PR TITLE
Use env var for backend URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Mastra Weather AI
+
+This repository contains the backend and frontend for the Mastra Weather AI assistant.
+
+## Environment Variables
+
+The frontend reads `MASTRA_BACKEND_URL` to determine where the backend is running. If this variable is not set, the default `http://127.0.0.1:8000/mastra` is used.
+
+Add this variable to `mastra-frontend/.env.local` when deploying or running locally.

--- a/mastra-frontend/README.md
+++ b/mastra-frontend/README.md
@@ -20,11 +20,13 @@ The frontend application for the Mastra Weather AI Assistant, built with Next.js
 
 2. **Set up environment variables**
 
-   Create a `.env.local` file:
+  Create a `.env.local` file:
 
-   ```env
-   NEXT_PUBLIC_COPILOTKIT_API_URL=http://localhost:4000/api/copilotkit
-   ```
+  ```env
+  NEXT_PUBLIC_COPILOTKIT_API_URL=http://localhost:4000/api/copilotkit
+  # URL where the backend is running
+  MASTRA_BACKEND_URL=http://127.0.0.1:8000/mastra
+  ```
 
 3. **Start the development server**
 

--- a/mastra-frontend/src/app/api/copilotkit/route.ts
+++ b/mastra-frontend/src/app/api/copilotkit/route.ts
@@ -11,9 +11,11 @@ import {
 // Import NextRequest type for handling Next.js API requests
 import { NextRequest } from "next/server";
 
-// Create a new HttpAgent instance that connects to the Mastra backend running locally
+// Create a new HttpAgent instance that connects to the Mastra backend
+// The backend URL can be configured with the `MASTRA_BACKEND_URL` environment variable
+// and defaults to the local development address.
 const RAGAgent = new HttpAgent({
-  url: "http://127.0.0.1:8000/mastra",
+  url: process.env.MASTRA_BACKEND_URL ?? "http://127.0.0.1:8000/mastra",
 });
 
 // Initialize the CopilotKit runtime with our research agent


### PR DESCRIPTION
## Summary
- make the CopilotKit backend URL configurable via `MASTRA_BACKEND_URL`
- note the new variable in both READMEs

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_6840df1594ec83338ddf249ba9e054b9