### PR TITLE
Replace weather references with Graph RAG

### DIFF
--- a/mastra-frontend/README.md
+++ b/mastra-frontend/README.md
@@ -1,6 +1,6 @@
-# Mastra Weather AI - Frontend
+# Mastra Graph RAG Assistant - Frontend
 
-The frontend application for the Mastra Weather AI Assistant, built with Next.js 15, CopilotKit, and Tailwind CSS.
+The frontend application for the Mastra Graph RAG Assistant, built with Next.js 15, CopilotKit, and Tailwind CSS.
 
 ## 🚀 Quick Start
 
@@ -45,7 +45,7 @@ src/
 ├── app/
 │   ├── api/copilotkit/route.ts    # CopilotKit API integration
 │   ├── copilotkit/                # Chat interface pages
-│   ├── components/Weather.tsx     # Weather display component
+│   ├── components/RAG.tsx        # Graph RAG UI component
 │   ├── layout.tsx                 # Root layout with Header
 │   ├── page.tsx                   # Landing page
 │   └── globals.css               # Global styles
@@ -99,7 +99,7 @@ The chat interface is powered by CopilotKit:
 
 - Chat components are in `src/app/copilotkit/`
 - API route handles backend communication in `src/app/api/copilotkit/route.ts`
-- Weather-specific UI in `src/app/components/Weather.tsx`
+- Graph RAG UI in `src/app/components/RAG.tsx`
 
 ## 🚀 Deployment
 

--- a/mastra-frontend/src/app/components/RAG.tsx
+++ b/mastra-frontend/src/app/components/RAG.tsx
@@ -103,13 +103,13 @@ function RAG() {
               <line x1="9" y1="9" x2="15" y2="15"></line>
             </svg>
             <h3 className="text-lg font-semibold text-red-800">
-              Weather Error
+              Graph RAG Error
             </h3>
           </div>
 
           <p className="text-red-700 mb-4">
             {state.error ||
-              "Unable to retrieve weather information. Please try again."}
+              "Unable to retrieve graph information. Please try again."}
           </p>
 
           <button
@@ -174,7 +174,7 @@ function RAG() {
     );
   }
 
-  // If weather request is in progress, show loading state
+  // If graph request is in progress, show loading state
   if (
     state?.status &&
     state.status !== "completed" &&
@@ -184,7 +184,7 @@ function RAG() {
       <div className="flex flex-col gap-4 h-full max-w-4xl mt-4 mx-auto">
         <div className="p-6 bg-white border rounded-lg shadow-sm w-full">
           <h3 className="text-xl font-semibold mb-4">
-            Getting Weather Information
+            Processing Graph RAG Query
           </h3>
 
           <div className="status-container mb-6">
@@ -202,7 +202,7 @@ function RAG() {
               { stage: "analyzing_request", label: "Analyzing Request" },
               {
                 stage: "fetching_weather_data",
-                label: "Fetching Weather Data",
+                label: "Retrieving Graph Data",
               },
               { stage: "formatting_response", label: "Formatting Response" },
             ].map(({ stage, label }) => {
@@ -259,23 +259,23 @@ function RAG() {
     <div className="flex flex-col gap-4 h-full max-w-4xl mt-4 mx-auto">
       <div className="p-6 bg-white rounded-lg shadow-sm border border-gray-200 w-full">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-xl font-semibold">Weather Assistant</h3>
+          <h3 className="text-xl font-semibold">Graph RAG Assistant</h3>
           <div className="text-sm px-3 py-1 bg-gray-100 rounded-full">
             Ready
           </div>
         </div>
         <div className="text-gray-600 mb-4">
           <p>
-            Ask me about the weather for any location and I&apos;ll provide
-            current conditions and forecasts.
+            Ask me questions about your knowledge graph and I&apos;ll return
+            answers with relevant context.
           </p>
         </div>{" "}
         <div className="bg-gray-50 p-4 rounded-md">
           <h4 className="font-medium text-gray-800 mb-2">Examples:</h4>
           <ul className="text-sm text-gray-600 space-y-1">
-            <li>• &quot;What&apos;s the weather like in New York?&quot;</li>
-            <li>• &quot;Show me the forecast for Tokyo&quot;</li>
-            <li>• &quot;Is it going to rain in London today?&quot;</li>
+            <li>• &quot;How is Alice connected to Bob?&quot;</li>
+            <li>• &quot;List documents related to Project X&quot;</li>
+            <li>• &quot;Show relationships for node 42&quot;</li>
           </ul>
         </div>
       </div>

--- a/mastra-frontend/src/app/globals.css
+++ b/mastra-frontend/src/app/globals.css
@@ -114,28 +114,28 @@
   }
 }
 
-/* Custom weather report styling */
-.weather-report {
+/* Styling for RAG answers */
+.rag-answer {
   font-feature-settings: "kern" 1, "liga" 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.weather-report p {
+.rag-answer p {
   line-height: 1.6;
   margin-bottom: 0.75rem;
 }
 
-.weather-report p:last-child {
+.rag-answer p:last-child {
   margin-bottom: 0;
 }
 
 /* Better emoji rendering */
-.weather-report p,
-.weather-report li,
-.weather-report h1,
-.weather-report h2,
-.weather-report h3 {
+.rag-answer p,
+.rag-answer li,
+.rag-answer h1,
+.rag-answer h2,
+.rag-answer h3 {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji";

--- a/mastra-frontend/src/app/page.tsx
+++ b/mastra-frontend/src/app/page.tsx
@@ -111,7 +111,7 @@ export default function Home() {
                           </div>
                           <div className="flex-1">
                             <p className="text-sm text-gray-600">
-                              Feed me some documentation and i'll be an expert advisor!
+                              Feed me some documentation and I&apos;ll be an expert advisor!
                             </p>
                           </div>
                         </div>

--- a/mastra-frontend/src/components/Footer.tsx
+++ b/mastra-frontend/src/components/Footer.tsx
@@ -21,8 +21,8 @@ export default function Footer() {
               <span className="text-xl font-bold">Mastra</span>
             </div>
             <p className="text-gray-400 text-sm">
-              Intelligent weather forecasting powered by AI. Experience the
-              future of weather predictions.
+              Answers powered by graph retrieval. Explore connections in your
+              data with AI assistance.
             </p>
           </div>
 
@@ -36,7 +36,7 @@ export default function Footer() {
                 <Link
                   href="/copilotkit"
                   className="text-gray-400 hover:text-white transition-colors">
-                  Weather AI
+                  Graph RAG
                 </Link>
               </li>
               <li>
@@ -131,7 +131,7 @@ export default function Footer() {
         <div className="mt-12 pt-8 border-t border-gray-800">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <p className="text-gray-400 text-sm">
-              © 2024 Mastra Weather AI. All rights reserved.
+              © 2024 Mastra Graph RAG Assistant. All rights reserved.
             </p>
             <div className="mt-4 md:mt-0 flex space-x-6">
               <Link

--- a/mastra-frontend/src/components/Header.tsx
+++ b/mastra-frontend/src/components/Header.tsx
@@ -37,7 +37,7 @@ export default function Header() {
             <Link
               href="/copilotkit"
               className="text-sm font-medium text-foreground/80 hover:text-foreground transition-colors">
-              Weather AI
+              Graph RAG
             </Link>
             <Link
               href="#features"
@@ -56,7 +56,7 @@ export default function Header() {
             <Link
               href="/copilotkit"
               className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50">
-              Try Weather AI
+              Try Graph RAG
             </Link>
           </div>
 
@@ -116,7 +116,7 @@ export default function Header() {
                 href="/copilotkit"
                 className="block px-3 py-2 text-base font-medium text-foreground/80 hover:text-foreground hover:bg-accent rounded-md"
                 onClick={() => setIsMenuOpen(false)}>
-                Weather AI
+                Graph RAG
               </Link>
               <Link
                 href="#features"
@@ -135,7 +135,7 @@ export default function Header() {
                   href="/copilotkit"
                   className="block w-full text-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
                   onClick={() => setIsMenuOpen(false)}>
-                  Try Weather AI
+                  Try Graph RAG
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- rename weather references in RAG component and default content
- change header and footer links to Graph RAG
- update project README for Graph RAG assistant
- switch weather-report styles to rag-answer
- fix lint issue in page.tsx

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840e1b014508333a37ee9f3b042e722