### PR TITLE
Fix agent naming

### DIFF
--- a/mastra-frontend/src/app/api/copilotkit/route.ts
+++ b/mastra-frontend/src/app/api/copilotkit/route.ts
@@ -14,14 +14,14 @@ import { NextRequest } from "next/server";
 // Create a new HttpAgent instance that connects to the Mastra backend
 // The backend URL can be configured with the `MASTRA_BACKEND_URL` environment variable
 // and defaults to the local development address.
-const RAGAgent = new HttpAgent({
+const RAGAgentQuery = new HttpAgent({
   url: process.env.MASTRA_BACKEND_URL ?? "http://127.0.0.1:8000/mastra",
 });
 
 // Initialize the CopilotKit runtime with our research agent
 const runtime = new CopilotRuntime({
   agents: {
-    RAGAgent, // Register the research agent with the runtime
+    RAGAgentQuery, // Register the research agent with the runtime
   },
 });
 

--- a/mastra-frontend/src/app/components/RAG.tsx
+++ b/mastra-frontend/src/app/components/RAG.tsx
@@ -9,7 +9,7 @@ function RAG() {
   // Reference to track if RAG request is in progress
   const isRAGInProgress = useRef(false); // Connect to the RAG agent's state using CopilotKit's useCoAgent hook
   const { state, stop: stopRAGAgent } = useCoAgent<RAGAgentState>({
-    name: "RAGAgent",
+    name: "RAGAgentQuery",
     initialState: {
       status: "initializing",
       currentStep: "RAGAgent_analysis",
@@ -21,7 +21,7 @@ function RAG() {
 
   // Implement useCoAgentStateRender hook
   useCoAgentStateRender({
-    name: "RAGAgent",
+    name: "RAGAgentQuery",
     handler: ({ nodeName }) => {
       // Handle completion when the RAG agent finishes
       if (nodeName === "__end__" || state?.status === "completed") {

--- a/mastra-frontend/src/app/copilotkit/layout.tsx
+++ b/mastra-frontend/src/app/copilotkit/layout.tsx
@@ -14,7 +14,7 @@ const publicApiKey = process.env.NEXT_PUBLIC_COPILOT_API_KEY;
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <CopilotKit publicApiKey={publicApiKey} // The public API key for Copilot Cloud
-      agent="RAGAgent" // The name of the agent to use
+      agent="RAGAgentQuery" // The name of the agent to use
       showDevConsole={false} // Show the dev console for debugging
     >
       {children}

--- a/mastra-frontend/src/app/layout.tsx
+++ b/mastra-frontend/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
         <Header />
         <CopilotKit
           publicApiKey={publicApiKey}
-          agent="RAGAgent"
+          agent="RAGAgentQuery"
           showDevConsole={false}>
           {children}
         </CopilotKit>


### PR DESCRIPTION
## Summary
- make sure `useCoAgent` and `<CopilotKit>` use the "RAGAgentQuery" name
- update runtime to register the same agent name

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841e9f25f4483338360a3bf54d65c6f