### PR TITLE
Align RAG index names across agents

### DIFF
--- a/mastra-backend/src/mastra/agents/RAGAgent.ts
+++ b/mastra-backend/src/mastra/agents/RAGAgent.ts
@@ -11,7 +11,8 @@ const vllm0 = createOpenAICompatible({
 
 const graphRagTool = createGraphRAGTool({
   vectorStoreName: "pgVector",
-  indexName: "docs",
+  // Use the shared "embeddings" index for RAG operations
+  indexName: "embeddings",
   model: vllm0.textEmbeddingModel("bge-large"),
   // model: ollama.embedding("bge-large"),
   // model: openai.embedding("text-embedding-3-small"),

--- a/mastra-backend/src/mastra/agents/VectorStoreAgent.ts
+++ b/mastra-backend/src/mastra/agents/VectorStoreAgent.ts
@@ -73,7 +73,7 @@ export const vectorizeTool = createTool ({
     // Use PostgreSQL vector store
     const vectorStore = mastra.getVector("pgVector");
     
-    // Create index if it doesn't exist (will ignore if already exists)
+    // Create the shared "embeddings" index if it doesn't exist
     try {
       await vectorStore.createIndex({
         indexName: "embeddings",
@@ -90,6 +90,7 @@ export const vectorizeTool = createTool ({
       }
     }
 
+    // Upsert vectors into the shared "embeddings" index
     await vectorStore.upsert({
         indexName: "embeddings",
         vectors: embeddings,


### PR DESCRIPTION
## Summary
- use the same `embeddings` index in GraphRAG and vector store
- document use of the shared index for clarity

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841eaee9f9483338db3a1baab36158c