### PR TITLE
Fix outdated tool note

### DIFF
--- a/mastra-backend/src/mastra/index.ts
+++ b/mastra-backend/src/mastra/index.ts
@@ -36,4 +36,4 @@ export const mastra = new Mastra({
   },
 });
 
-// Note: vectorizeTool is already included in RAGAgentQuery.tools for agent tool execution
+// vectorizeTool is exposed by VectorStoreAgent (see ./agents/VectorStoreAgent.ts)


### PR DESCRIPTION
## Summary
- update a comment in the backend to correctly describe where `vectorizeTool` lives

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec0dc46c833399a61a9df7a9fc84